### PR TITLE
Fixed handling of HTTPS URLs

### DIFF
--- a/gitname.py
+++ b/gitname.py
@@ -42,7 +42,8 @@ def gitname(args):
     if '://' not in remote:
         remote = 'scheme://%s' % remote
 
-    remote_items = re.split('://|@|:|/', remote)[2:]
+    drop_items = 1 if remote.startswith('https') else 2
+    remote_items = re.split('://|@|:|/', remote)[drop_items:]
     remote_host = remote_items[0]
 
     config = ConfigParser.SafeConfigParser()


### PR DESCRIPTION
Currently gitname supports only SSH remotes. Some people are miserable and have to use HTTPS remotes (for example because Git LFS does not work over SSH).

For example given:

```
$ git remote -v
origin	https://mysite.com/myproject/_git/myrepo (fetch)
origin	https://mysite.com/myproject/_git/myrepo (push)
```

I can not configure gitname using `mysite.com` section as it strips first 2 sections from the URL (in SSH there used to be username). This is rather a quick fix. Ideally it should use something like https://github.com/FriendCode/giturlparse.py instead of ad-hoc solution.