### PR TITLE
Remove deprecated Homebrew option

### DIFF
--- a/formula/gitname.rb
+++ b/formula/gitname.rb
@@ -6,7 +6,6 @@ class Gitname < Formula
   desc "Simple script to set git config properties in git repository based on remote url."
   homepage "https://github.com/alex-shpak/gitname"
   version "5"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/alex-shpak/gitname/releases/download/v5/gitname_5_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
As it caused warning to be printed whenever interacting with Homebrew. See https://stackoverflow.com/a/45163490/1377864 and https://github.com/goreleaser/goreleaser/issues/2595.